### PR TITLE
Convert Book frontend to use Backend

### DIFF
--- a/frontend/src/main/components/Books/BookTable.js
+++ b/frontend/src/main/components/Books/BookTable.js
@@ -1,30 +1,11 @@
 import React from "react";
 import OurTable, { ButtonColumn } from "main/components/OurTable";
-import { useNavigate } from "react-router-dom";
 import { useBackendMutation } from "main/utils/useBackend";
-import { toast } from "react-toastify";
+import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/bookUtils"
+import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
 
-export default function BookTable({
-    books,
-    showButtons = true,
-    testIdPrefix = "BookTable",
-    currentUser = null }) {
-
-    const onDeleteSuccess = message => {
-        console.log(message);
-        toast(message);
-    };
-
-    const objectToAxiosParams = function (cell) {
-        return {
-            url: "/api/books",
-            method: "DELETE",
-            params: {
-                id: cell.row.values.id
-            }
-        };
-    };
+export default function BookTable({ books, currentUser, showButtons=true, testIdPrefix="BookTable" }) {
 
     const navigate = useNavigate();
 
@@ -36,16 +17,17 @@ export default function BookTable({
         navigate(`/books/details/${cell.row.values.id}`)
     }
 
-    const deleteCallback = async (cell) => {
-        deleteMutation.mutate(cell);
-    };
-
     // Stryker disable all : hard to test for query caching
+
     const deleteMutation = useBackendMutation(
-        objectToAxiosParams,
+        cellToAxiosParamsDelete,
         { onSuccess: onDeleteSuccess },
         ["/api/books/all"]
     );
+    // Stryker enable all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
 
 
     const columns = [
@@ -76,9 +58,13 @@ export default function BookTable({
         }
     }
 
+    // Stryker disable next-line ArrayDeclaration : [columns] is a performance optimization
+    const memoizedColumns = React.useMemo(() => columns, [columns]);
+    const memoizedDates = React.useMemo(() => books, [books]);
+
     return <OurTable
-        data={books}
-        columns={columns}
+        data={memoizedDates}
+        columns={memoizedColumns}
         testid={testIdPrefix}
     />;
 };

--- a/frontend/src/main/components/Books/BookTable.js
+++ b/frontend/src/main/components/Books/BookTable.js
@@ -1,40 +1,36 @@
 import React from "react";
 import OurTable, { ButtonColumn } from "main/components/OurTable";
 import { useNavigate } from "react-router-dom";
-import { bookUtils } from "main/utils/bookUtils";
+import { useBackendMutation } from "main/utils/useBackend";
+import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/bookUtils";
+import { hasRole } from "main/utils/currentUser";
 
-const showCell = (cell) => JSON.stringify(cell.row.values);
-
-
-const defaultDeleteCallback = async (cell) => {
-    console.log(`deleteCallback: ${showCell(cell)})`);
-    bookUtils.del(cell.row.values.id);
-}
-
-export default function BookTable({
-    books,
-    deleteCallback = defaultDeleteCallback,
-    showButtons = true,
-    testIdPrefix = "BookTable" }) {
+export default function BookTable({ books, currentUser }) {
 
     const navigate = useNavigate();
- 
+
     const editCallback = (cell) => {
-        console.log(`editCallback: ${showCell(cell)})`);
         navigate(`/books/edit/${cell.row.values.id}`)
     }
 
-    const detailsCallback = (cell) => {
-        console.log(`detailsCallback: ${showCell(cell)})`);
-        navigate(`/books/details/${cell.row.values.id}`)
-    }
+    // Stryker disable all : hard to test for query caching
+
+    const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/books/all"]
+    );
+    // Stryker enable all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+
 
     const columns = [
         {
             Header: 'id',
             accessor: 'id', // accessor is the "key" in the data
         },
-
         {
             Header: 'Name',
             accessor: 'name',
@@ -49,20 +45,18 @@ export default function BookTable({
         }
     ];
 
-    const buttonColumns = [
-        ...columns,
-        ButtonColumn("Details", "primary", detailsCallback, testIdPrefix),
-        ButtonColumn("Edit", "primary", editCallback, testIdPrefix),
-        ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix),
-    ]
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+        columns.push(ButtonColumn("Edit", "primary", editCallback, "BookTable"));
+        columns.push(ButtonColumn("Delete", "danger", deleteCallback, "BookTable"));
+    } 
 
-    const columnsToDisplay = showButtons ? buttonColumns : columns;
+    // Stryker disable next-line ArrayDeclaration : [columns] is a performance optimization
+    const memoizedColumns = React.useMemo(() => columns, [columns]);
+    const memoizedBooks = React.useMemo(() => books, [books]);
 
     return <OurTable
-        data={books}
-        columns={columnsToDisplay}
-        testid={testIdPrefix}
+        data={memoizedBooks}
+        columns={memoizedColumns}
+        testid={"BookTable"}
     />;
 };
-
-export { showCell };

--- a/frontend/src/main/components/Books/BookTable.js
+++ b/frontend/src/main/components/Books/BookTable.js
@@ -46,6 +46,7 @@ export default function BookTable({ books, currentUser }) {
     ];
 
     if (hasRole(currentUser, "ROLE_ADMIN")) {
+        columns.push(ButtonColumn("Details", "primary", editCallback, "BookTable"));
         columns.push(ButtonColumn("Edit", "primary", editCallback, "BookTable"));
         columns.push(ButtonColumn("Delete", "danger", deleteCallback, "BookTable"));
     } 

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -95,7 +95,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
               {
                 hasRole(currentUser, "ROLE_USER") && (
                   <NavDropdown title="Books" id="appnavbar-books-dropdown" data-testid="appnavbar-books-dropdown" >
-                    <NavDropdown.Item href="/books/list" data-testid="appnavbar-books-list">List</NavDropdown.Item>
+                    <NavDropdown.Item href="/books" data-testid="appnavbar-books-list">List</NavDropdown.Item>
                     {
                       hasRole(currentUser, "ROLE_ADMIN") && (
                         <NavDropdown.Item href="/books/create" data-testid="appnavbar-books-create">Create</NavDropdown.Item>

--- a/frontend/src/main/pages/Books/BookCreatePage.js
+++ b/frontend/src/main/pages/Books/BookCreatePage.js
@@ -1,16 +1,40 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
-import { useNavigate } from "react-router-dom";
+import { Navigate } from "react-router-dom";
 import BookForm from "main/components/Books/BookForm";
-import { bookUtils } from "main/utils/bookUtils";
+import { toast } from "react-toastify";
+import { useBackendMutation } from "main/utils/useBackend";
 
 export default function BookCreatePage() {
-  let navigate = useNavigate();
+  const objectToAxiosParams = (book) => ({
+    url: "/api/books/post",
+    method: "POST",
+    params: {
+      name: book.name,
+      author: book.author,
+      genre: book.genre
+    }
+  });
 
-  const onSubmit = async (book) => {
-    const createdBook = bookUtils.add(book);
-    console.log("createdBook: " + JSON.stringify(createdBook));
-    navigate("/books");
-  };
+  const onSuccess = (book) => {
+    toast(`New book Created - id: ${book.id} name: ${book.name}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+     { onSuccess }, 
+     // Stryker disable next-line all : hard to set up test for caching
+     ["/api/books/all"]
+     );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess) {
+    return <Navigate to="/books/" />
+  }
 
   return (
     <BasicLayout>

--- a/frontend/src/main/pages/Books/BookDetailsPage.js
+++ b/frontend/src/main/pages/Books/BookDetailsPage.js
@@ -26,7 +26,7 @@ export default function BookDetailsPage() {
     <BasicLayout>
       <div className="pt-2">
         <h1>Book Details</h1>
-        {book && <BookTable books={[book]} currentUser={currentUser} showButtons={false} /> }  
+        {book && <BookTable books={[book]} currentUser={currentUser} /> }  
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/pages/Books/BookDetailsPage.js
+++ b/frontend/src/main/pages/Books/BookDetailsPage.js
@@ -27,7 +27,7 @@ export default function BookDetailsPage() {
     <BasicLayout>
       <div className="pt-2">
         <h1>Book Details</h1>
-        {book && <BookTable books={[book]} currentUser={currentUser} /> }  
+        {book && <BookTable books={[book]} currentUser={currentUser} showButtons={false} /> }  
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/pages/Books/BookDetailsPage.js
+++ b/frontend/src/main/pages/Books/BookDetailsPage.js
@@ -11,6 +11,7 @@ export default function BookDetailsPage() {
 
   const { data: book, error: _error, status: _status } =
     useBackend(
+      // Stryker disable next-line all : don't test internal caching of ReactQuery
       [`/api/books?id=${id}`],
       {
         // Stryker disable next-line all : don't test internal caching of React Query

--- a/frontend/src/main/pages/Books/BookDetailsPage.js
+++ b/frontend/src/main/pages/Books/BookDetailsPage.js
@@ -1,18 +1,29 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import { useParams } from "react-router-dom";
 import BookTable from 'main/components/Books/BookTable';
-import { bookUtils } from 'main/utils/bookUtils';
+import { useBackend } from "main/utils/useBackend";
 
 export default function BookDetailsPage() {
   let { id } = useParams();
 
-  const response = bookUtils.getById(id);
+  const { data: book, error: _error, status: _status } =
+    useBackend(
+      [`/api/books?id=${id}`],
+      {
+        // Stryker disable next-line all : don't test internal caching of React Query
+        method: "GET",
+        url: `/api/books`,
+        params: {
+          id
+        }
+      }
+    );
 
   return (
     <BasicLayout>
       <div className="pt-2">
         <h1>Book Details</h1>
-        <BookTable books={[response.book]} showButtons={false} />
+        {book && <BookTable books={[book]} showButtons={false} /> }  
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/pages/Books/BookDetailsPage.js
+++ b/frontend/src/main/pages/Books/BookDetailsPage.js
@@ -2,9 +2,12 @@ import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import { useParams } from "react-router-dom";
 import BookTable from 'main/components/Books/BookTable';
 import { useBackend } from "main/utils/useBackend";
+import { useCurrentUser } from "main/utils/currentUser";
 
 export default function BookDetailsPage() {
   let { id } = useParams();
+
+  const currentUser = useCurrentUser();
 
   const { data: book, error: _error, status: _status } =
     useBackend(
@@ -23,7 +26,7 @@ export default function BookDetailsPage() {
     <BasicLayout>
       <div className="pt-2">
         <h1>Book Details</h1>
-        {book && <BookTable books={[book]} showButtons={false} /> }  
+        {book && <BookTable books={[book]} currentUser={currentUser} showButtons={false} /> }  
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/pages/Books/BookEditPage.js
+++ b/frontend/src/main/pages/Books/BookEditPage.js
@@ -1,30 +1,73 @@
 
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import { useParams } from "react-router-dom";
-import { bookUtils }  from 'main/utils/bookUtils';
 import BookForm from 'main/components/Books/BookForm';
 import { useNavigate } from 'react-router-dom'
+import { toast } from "react-toastify";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { Navigate } from "react-router-dom";
 
 
 export default function BookEditPage() {
     let { id } = useParams();
 
-    let navigate = useNavigate();
-
-    const response = bookUtils.getById(id);
-
-    const onSubmit = async (book) => {
-        const updatedBook = bookUtils.update(book);
-        console.log("updatedBook: " + JSON.stringify(updatedBook));
-        navigate("/books");
+    const { data: book, error, status } =
+      useBackend(
+        // Stryker disable next-line all : don't test internal caching of React Query
+        [`/api/books?id=${id}`],
+        {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+          method: "GET",
+          url: `/api/books`,
+          params: {
+            id
+          }
+        }
+      );
+  
+  
+    const objectToAxiosPutParams = (book) => ({
+      url: "/api/books",
+      method: "PUT",
+      params: {
+        id: book.id,
+      },
+      data: {
+        title: book.title,
+        author: book.author,
+        genre: book.genre
+      }
+    });
+  
+    const onSuccess = (book) => {
+      toast(`Book Updated - id: ${book.id} name: ${book.name}`);
     }
-
+  
+    const mutation = useBackendMutation(
+      objectToAxiosPutParams,
+      { onSuccess },
+      // Stryker disable next-line all : hard to set up test for caching
+      [`/api/books?id=${id}`]
+    );
+  
+    const { isSuccess } = mutation
+  
+    const onSubmit = async (data) => {
+      mutation.mutate(data);
+    }
+  
+    if (isSuccess) {
+      return <Navigate to="/books/" />
+    }
+  
     return (
-        <BasicLayout>
-            <div className="pt-2">
-                <h1>Edit Book</h1>
-                <BookForm submitAction={onSubmit} buttonLabel={"Update"} initialContents={response.book}/>
-            </div>
-        </BasicLayout>
+      <BasicLayout>
+        <div className="pt-2">
+          <h1>Edit Book</h1>
+          {book &&
+            <BookForm initialContents={book} submitAction={onSubmit} buttonLabel="Update" />
+          }
+        </div>
+      </BasicLayout>
     )
-}
+  }
+  

--- a/frontend/src/main/pages/Books/BookEditPage.js
+++ b/frontend/src/main/pages/Books/BookEditPage.js
@@ -32,7 +32,7 @@ export default function BookEditPage() {
         id: book.id,
       },
       data: {
-        title: book.title,
+        name: book.name,
         author: book.author,
         genre: book.genre
       }

--- a/frontend/src/main/pages/Books/BookIndexPage.js
+++ b/frontend/src/main/pages/Books/BookIndexPage.js
@@ -20,9 +20,6 @@ export default function BookIndexPage() {
   return (
     <BasicLayout>
       <div className="pt-2">
-        <Button style={{ float: "right" }} as={Link} to="/books/create">
-          Create Book
-        </Button>
         <h1>Books</h1>
         <BookTable books={books} currentUser={currentUser} />
       </div>

--- a/frontend/src/main/pages/Books/BookIndexPage.js
+++ b/frontend/src/main/pages/Books/BookIndexPage.js
@@ -2,33 +2,30 @@ import React from 'react'
 import Button from 'react-bootstrap/Button';
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import BookTable from 'main/components/Books/BookTable';
-import { bookUtils } from 'main/utils/bookUtils';
-import { useNavigate, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useCurrentUser } from 'main/utils/currentUser';
+import { useBackend } from 'main/utils/useBackend';
 
 export default function BookIndexPage() {
+  const currentUser = useCurrentUser();
 
-    const navigate = useNavigate();
+  const { data: books, error: _error, status: _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      ["/api/books/all"],
+      { method: "GET", url: "/api/books/all" },
+      []
+    );
 
-    const bookCollection = bookUtils.get();
-    const books = bookCollection.books;
-
-    const showCell = (cell) => JSON.stringify(cell.row.values);
-
-    const deleteCallback = async (cell) => {
-        console.log(`BookIndexPage deleteCallback: ${showCell(cell)})`);
-        bookUtils.del(cell.row.values.id);
-        navigate("/books");
-    }
-
-    return (
-        <BasicLayout>
-            <div className="pt-2">
-                <Button style={{ float: "right" }} as={Link} to="/books/create">
-                    Create Book
-                </Button>
-                <h1>Books</h1>
-                <BookTable books={books} deleteCallback={deleteCallback} />
-            </div>
-        </BasicLayout>
-    )
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <Button style={{ float: "right" }} as={Link} to="/books/create">
+          Create Book
+        </Button>
+        <h1>Books</h1>
+        <BookTable books={books} currentUser={currentUser} />
+      </div>
+    </BasicLayout>
+  )
 }

--- a/frontend/src/main/pages/Books/BookIndexPage.js
+++ b/frontend/src/main/pages/Books/BookIndexPage.js
@@ -20,6 +20,9 @@ export default function BookIndexPage() {
   return (
     <BasicLayout>
       <div className="pt-2">
+        <Button style={{ float: "right" }} as={Link} to="/books/create">
+          Create Book
+        </Button>
         <h1>Books</h1>
         <BookTable books={books} currentUser={currentUser} />
       </div>

--- a/frontend/src/main/utils/bookUtils.js
+++ b/frontend/src/main/utils/bookUtils.js
@@ -1,92 +1,18 @@
-// get books from local storage
-const get = () => {
-    const bookValue = localStorage.getItem("books");
-    if (bookValue === undefined) {
-        const bookCollection = { nextId: 1, books: [] }
-        return set(bookCollection);
-    }
-    const bookCollection = JSON.parse(bookValue);
-    if (bookCollection === null) {
-        const bookCollection = { nextId: 1, books: [] }
-        return set(bookCollection);
-    }
-    return bookCollection;
-};
+import { toast } from "react-toastify";
+import { useNavigate } from 'react-router-dom'
 
-const getById = (id) => {
-    if (id === undefined) {
-        return { "error": "id is a required parameter" };
-    }
-    const bookCollection = get();
-    const books = bookCollection.books;
-
-    /* eslint-disable-next-line eqeqeq */ // we really do want == here, not ===
-    const index = books.findIndex((r) => r.id == id);
-    if (index === -1) {
-        return { "error": `book with id ${id} not found` };
-    }
-    return { book: books[index] };
+export function onDeleteSuccess(message) {
+    console.log(message);
+    toast(message);
 }
 
-// set books in local storage
-const set = (bookCollection) => {
-    localStorage.setItem("books", JSON.stringify(bookCollection));
-    return bookCollection;
-};
-
-// add a book to local storage
-const add = (book) => {
-    const bookCollection = get();
-    book = { ...book, id: bookCollection.nextId };
-    bookCollection.nextId++;
-    bookCollection.books.push(book);
-    set(bookCollection);
-    return book;
-};
-
-// update a book in local storage
-const update = (book) => {
-    const bookCollection = get();
-
-    const books = bookCollection.books;
-
-    /* eslint-disable-next-line eqeqeq */ // we really do want == here, not ===
-    const index = books.findIndex((r) => r.id == book.id);
-    if (index === -1) {
-        return { "error": `book with id ${book.id} not found` };
+export function cellToAxiosParamsDelete(cell) {
+    return {
+        url: "/api/books",
+        method: "DELETE",
+        params: {
+            id: cell.row.values.id
+        }
     }
-    books[index] = book;
-    set(bookCollection);
-    return { bookCollection: bookCollection };
-};
-
-// delete a book from local storage
-const del = (id) => {
-    if (id === undefined) {
-        return { "error": "id is a required parameter" };
-    }
-    const bookCollection = get();
-    const books = bookCollection.books;
-
-    /* eslint-disable-next-line eqeqeq */ // we really do want == here, not ===
-    const index = books.findIndex((r) => r.id == id);
-    if (index === -1) {
-        return { "error": `book with id ${id} not found` };
-    }
-    books.splice(index, 1);
-    set(bookCollection);
-    return { bookCollection: bookCollection };
-};
-
-const bookUtils = {
-    get,
-    getById,
-    add,
-    update,
-    del
-};
-
-export { bookUtils };
-
-
+}
 

--- a/frontend/src/tests/components/Books/BookTable.test.js
+++ b/frontend/src/tests/components/Books/BookTable.test.js
@@ -1,213 +1,123 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
-import { QueryClient, QueryClientProvider } from "react-query";
-import BookTable, { showCell } from "main/components/Books/BookTable";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { bookFixtures } from "fixtures/bookFixtures";
-import mockConsole from "jest-mock-console";
+import BookTable from "main/components/Books/BookTable"
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+
 
 const mockedNavigate = jest.fn();
 
 jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useNavigate: () => mockedNavigate
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
 }));
 
-describe("BookTable tests", () => {
+describe("UserTable tests", () => {
   const queryClient = new QueryClient();
 
-  const expectedHeaders = ["id", "Name", "Author", "Genre"];
-  const expectedFields = ["id", "name", "author", "genre"];
-  const testId = "BookTable";
 
-  test("showCell function works properly", () => {
-    const cell = {
-      row: {
-        values: { a: 1, b: 2, c: 3 }
-      },
-    };
-    expect(showCell(cell)).toBe(`{"a":1,"b":2,"c":3}`);
-  });
-
-  test("renders without crashing for empty table", () => {
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <BookTable books={[]} />
-        </MemoryRouter>
-      </QueryClientProvider>
-    );
-  });
-
-
-
-  test("Has the expected column headers, content and buttons", () => {
+  test("renders without crashing for empty table with user not logged in", () => {
+    const currentUser = null;
 
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <BookTable books={bookFixtures.threeBooks} />
+          <BookTable books={[]} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
+
     );
+  });
+  test("renders without crashing for empty table for ordinary user", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <BookTable books={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+  test("renders without crashing for empty table for admin", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <BookTable books={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+  test("Has the expected colum headers and content for adminUser", () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    const { getByText, getByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <BookTable books={bookFixtures.threeBooks} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    const expectedHeaders = ["id", "Name", "Author", "Genre"];
+    const expectedFields = ["id", "name", "author", "genre"];
+    const testId = "BookTable";
 
     expectedHeaders.forEach((headerText) => {
-      const header = screen.getByText(headerText);
+      const header = getByText(headerText);
       expect(header).toBeInTheDocument();
     });
 
     expectedFields.forEach((field) => {
-      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
       expect(header).toBeInTheDocument();
     });
 
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("Hamlet");
+    expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
+    expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("3");
 
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("3");
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-name`)).toHaveTextContent("The Great Gatsby");
-
-    const detailsButton = screen.getByTestId(`${testId}-cell-row-0-col-Details-button`);
-    expect(detailsButton).toBeInTheDocument();
-    expect(detailsButton).toHaveClass("btn-primary");
-
-    const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    const editButton = getByTestId(`${testId}-cell-row-0-col-Edit-button`);
     expect(editButton).toBeInTheDocument();
     expect(editButton).toHaveClass("btn-primary");
 
-    const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
     expect(deleteButton).toBeInTheDocument();
     expect(deleteButton).toHaveClass("btn-danger");
 
   });
 
-  test("Has the expected column headers, content and no buttons when showButtons=false", () => {
+  test("Edit button navigates to the edit page for admin user", async () => {
 
-    render(
+    const currentUser = currentUserFixtures.adminUser;
+
+    const { getByText, getByTestId } = render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <BookTable books={bookFixtures.threeBooks} showButtons={false} />
+          <BookTable books={bookFixtures.threeBooks} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
+
     );
 
-    expectedHeaders.forEach((headerText) => {
-      const header = screen.getByText(headerText);
-      expect(header).toBeInTheDocument();
-    });
+    await waitFor(() => { expect(getByTestId(`BookTable-cell-row-0-col-id`)).toHaveTextContent("2"); });
 
-    expectedFields.forEach((field) => {
-      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
-      expect(header).toBeInTheDocument();
-    });
-
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("Hamlet");
-
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("3");
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-name`)).toHaveTextContent("The Great Gatsby");
-
-    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
-    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
-    expect(screen.queryByText("Details")).not.toBeInTheDocument();
-  });
-
-
-  test("Edit button navigates to the edit page", async () => {
-    // arrange
-    const restoreConsole = mockConsole();
-
-    // act - render the component
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <BookTable books={bookFixtures.threeBooks} />
-        </MemoryRouter>
-      </QueryClientProvider>
-    );
-
-    // assert - check that the expected content is rendered
-    expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("Hamlet");
-
-    const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    const editButton = getByTestId(`BookTable-cell-row-0-col-Edit-button`);
     expect(editButton).toBeInTheDocument();
-
-    // act - click the edit button
+    
     fireEvent.click(editButton);
 
-    // assert - check that the navigate function was called with the expected path
     await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/books/edit/2'));
 
-    // assert - check that the console.log was called with the expected message
-    expect(console.log).toHaveBeenCalled();
-    const message = console.log.mock.calls[0][0];
-    const expectedMessage = `editCallback: {"id":2,"name":"Hamlet","author":"William Shakespeare","genre":"Shakespearean tragedy"})`;
-    expect(message).toMatch(expectedMessage);
-    restoreConsole();
   });
 
-  test("Details button navigates to the details page", async () => {
-    // arrange
-    const restoreConsole = mockConsole();
-
-    // act - render the component
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <BookTable books={bookFixtures.threeBooks} />
-        </MemoryRouter>
-      </QueryClientProvider>
-    );
-
-    // assert - check that the expected content is rendered
-    expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("Hamlet");
-
-    const detailsButton = screen.getByTestId(`${testId}-cell-row-0-col-Details-button`);
-    expect(detailsButton).toBeInTheDocument();
-
-    // act - click the details button
-    fireEvent.click(detailsButton);
-
-    // assert - check that the navigate function was called with the expected path
-    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/books/details/2'));
-
-    // assert - check that the console.log was called with the expected message
-    expect(console.log).toHaveBeenCalled();
-    const message = console.log.mock.calls[0][0];
-    const expectedMessage = `detailsCallback: {"id":2,"name":"Hamlet","author":"William Shakespeare","genre":"Shakespearean tragedy"})`;
-    expect(message).toMatch(expectedMessage);
-    restoreConsole();
-  });
-
-  test("Delete button calls delete callback", async () => {
-    // arrange
-    const restoreConsole = mockConsole();
-
-    // act - render the component
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <BookTable books={bookFixtures.threeBooks} />
-        </MemoryRouter>
-      </QueryClientProvider>
-    );
-
-    // assert - check that the expected content is rendered
-    expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("Hamlet");
-
-    const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
-    expect(deleteButton).toBeInTheDocument();
-
-     // act - click the delete button
-    fireEvent.click(deleteButton);
-
-     // assert - check that the console.log was called with the expected message
-     await(waitFor(() => expect(console.log).toHaveBeenCalled()));
-     const message = console.log.mock.calls[0][0];
-     const expectedMessage = `deleteCallback: {"id":2,"name":"Hamlet","author":"William Shakespeare","genre":"Shakespearean tragedy"})`;
-     expect(message).toMatch(expectedMessage);
-     restoreConsole();
-  });
 });
+

--- a/frontend/src/tests/components/Books/BookTable.test.js
+++ b/frontend/src/tests/components/Books/BookTable.test.js
@@ -1,9 +1,11 @@
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { fireEvent, queryByText, render, waitFor } from "@testing-library/react";
 import { bookFixtures } from "fixtures/bookFixtures";
 import BookTable from "main/components/Books/BookTable"
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import axios from "axios";
+import { AxiosMockAdapter } from "axios-mock-adapter";
 
 
 const mockedNavigate = jest.fn();

--- a/frontend/src/tests/components/Books/BookTable.test.js
+++ b/frontend/src/tests/components/Books/BookTable.test.js
@@ -18,12 +18,12 @@ describe("UserTable tests", () => {
 
 
   test("renders without crashing for empty table with user not logged in", () => {
-    const currentUser = null;
+    //const currentUser = null;
 
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <BookTable books={[]} currentUser={currentUser} />
+          <BookTable books={[]} />
         </MemoryRouter>
       </QueryClientProvider>
 
@@ -116,6 +116,30 @@ describe("UserTable tests", () => {
     fireEvent.click(editButton);
 
     await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/books/edit/2'));
+
+  });
+
+  test("Details button navigates to the details page", async () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    const { getByText, getByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <BookTable books={bookFixtures.threeBooks} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    await waitFor(() => { expect(getByTestId(`BookTable-cell-row-0-col-id`)).toHaveTextContent("2"); });
+
+    const detailsButton = getByTestId(`BookTable-cell-row-0-col-Details-button`);
+    expect(detailsButton).toBeInTheDocument();
+    
+    fireEvent.click(detailsButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/books/details/2'));
 
   });
 

--- a/frontend/src/tests/pages/Books/BookDetailsPage.test.js
+++ b/frontend/src/tests/pages/Books/BookDetailsPage.test.js
@@ -3,45 +3,55 @@ import BookDetailsPage from "main/pages/Books/BookDetailsPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
-import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
 const mockNavigate = jest.fn();
-jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    useParams: () => ({
-        id: 3
-    }),
-    useNavigate: () => mockNavigate
-}));
-
-jest.mock('main/utils/bookUtils', () => {
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
     return {
         __esModule: true,
-        bookUtils: {
-            getById: (_id) => {
-                return {
-                    book: {
-                        id: 3,
-                        name: "The Great Gatsby",
-                        author: "F. Scott Fitzgerald",
-                        genre: "Tragedy"
-                    }
-                }
-            }
-        }
-    }
+        ...originalModule,
+        useParams: () => ({
+            id: 1,
+            name: 'The Hobbit',
+            author: "J. R. R. Tolkien",
+            genre: "High Fantasy"
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
 });
 
 describe("BookDetailsPage tests", () => {
 
-    const axiosMock =new AxiosMockAdapter(axios);
-    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    const axiosMock = new AxiosMockAdapter(axios);
+    beforeEach(() => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        setupUserOnly();
+        axiosMock.onGet("/api/books", { params: { id: 1 } }).reply(200, {
+            id: 1,
+            name: "The Hobbit",
+            author: "J. R. R. Tolkien",
+            genre: "High Fantasy"
+        });
+    });
 
+    const testId = "BookTable";
     const queryClient = new QueryClient();
+
+    const setupUserOnly = () => {
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupAdminUser = () => {
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
     test("renders without crashing", () => {
         render(
             <QueryClientProvider client={queryClient}>
@@ -60,9 +70,9 @@ describe("BookDetailsPage tests", () => {
                 </MemoryRouter>
             </QueryClientProvider>
         );
-        expect(screen.getByText("The Great Gatsby")).toBeInTheDocument();
-        expect(screen.getByText("F. Scott Fitzgerald")).toBeInTheDocument();
-        expect(screen.getByText("Tragedy")).toBeInTheDocument();
+        expect(screen.getByText("The Hobbit")).toBeInTheDocument();
+        expect(screen.getByText("J. R. R. Tolkien")).toBeInTheDocument();
+        expect(screen.getByText("High Fantasy")).toBeInTheDocument();
 
         expect(screen.queryByText("Delete")).not.toBeInTheDocument();
         expect(screen.queryByText("Edit")).not.toBeInTheDocument();

--- a/frontend/src/tests/pages/Books/BookEditPage.test.js
+++ b/frontend/src/tests/pages/Books/BookEditPage.test.js
@@ -162,8 +162,8 @@ describe("BookEditPage tests", () => {
             expect(axiosMock.history.put.length).toBe(1); // times called
             expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
             expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
-                author: "J. R. R. Tolkien 2",
                 name: "The Hobbit 2",
+                author: "J. R. R. Tolkien 2",
                 genre: "High Fantasy 2"
             })); // posted object
 

--- a/frontend/src/tests/pages/Books/BookEditPage.test.js
+++ b/frontend/src/tests/pages/Books/BookEditPage.test.js
@@ -1,132 +1,177 @@
-import { render, screen, act, waitFor, fireEvent } from "@testing-library/react";
+import { render, waitFor, fireEvent } from "@testing-library/react";
 import BookEditPage from "main/pages/Books/BookEditPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import mockConsole from "jest-mock-console";
 
-import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
-const mockNavigate = jest.fn();
-
-jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    useParams: () => ({
-        id: 3
-    }),
-    useNavigate: () => mockNavigate
-}));
-
-const mockUpdate = jest.fn();
-jest.mock('main/utils/bookUtils', () => {
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
     return {
         __esModule: true,
-        bookUtils: {
-            update: (_book) => {return mockUpdate();},
-            getById: (_id) => {
-                return {
-                    book: {
-                        id: 3,
-                        name: "The Great Gatsby",
-                        author: "F. Scott Fitzgerald",
-                        genre: "Tragedy"
-                    }
-                }
-            }
-        }
-    }
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
 });
 
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            id: 17
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
 
 describe("BookEditPage tests", () => {
 
-    const axiosMock =new AxiosMockAdapter(axios);
-    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    describe("when the backend doesn't return a todo", () => {
 
-    const queryClient = new QueryClient();
+        const axiosMock = new AxiosMockAdapter(axios);
 
-    test("renders without crashing", () => {
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <BookEditPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
-    });
-
-    test("loads the correct fields", async () => {
-
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <BookEditPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
-
-        expect(screen.getByTestId("BookForm-name")).toBeInTheDocument();
-        expect(screen.getByDisplayValue('The Great Gatsby')).toBeInTheDocument();
-        expect(screen.getByDisplayValue('F. Scott Fitzgerald')).toBeInTheDocument();
-        expect(screen.getByDisplayValue('Tragedy')).toBeInTheDocument();
-    });
-
-    test("redirects to /books on submit", async () => {
-
-        const restoreConsole = mockConsole();
-
-        mockUpdate.mockReturnValue({
-            "book": {
-                id: 3,
-                name: "Calvin and Hobbes",
-                author: "Bill Watterson",
-                genre: "Humor"
-            }
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/books", { params: { id: 17 } }).timeout();
         });
 
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <BookEditPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        )
+        const queryClient = new QueryClient();
+        test("renders header but table is not present", async () => {
 
-        const nameInput = screen.getByLabelText("Name");
-        expect(nameInput).toBeInTheDocument();
+            const restoreConsole = mockConsole();
 
-        const authorInput = screen.getByLabelText("Author");
-        expect(authorInput).toBeInTheDocument();
-
-        const genreInput = screen.getByLabelText("Genre");
-        expect(genreInput).toBeInTheDocument();
-
-        const updateButton = screen.getByText("Update");
-        expect(updateButton).toBeInTheDocument();
-
-        await act(async () => {
-            fireEvent.change(nameInput, { target: { value: 'Calvin and Hobbes' } })
-            fireEvent.change(authorInput, { target: { value: 'Bill Watterson' } })
-            fireEvent.change(genreInput, { target: { value: 'Humor' } })
-            fireEvent.click(updateButton);
+            const {getByText, queryByTestId, findByText} = render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <BookEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+            await findByText("Edit Book");
+            expect(queryByTestId("BookForm-name")).not.toBeInTheDocument();
+            restoreConsole();
         });
-
-        await waitFor(() => expect(mockUpdate).toHaveBeenCalled());
-        await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/books"));
-
-        // assert - check that the console.log was called with the expected message
-        expect(console.log).toHaveBeenCalled();
-        const message = console.log.mock.calls[0][0];
-        const expectedMessage =  `updatedBook: {"book":{"id":3,"name":"Calvin and Hobbes","author":"Bill Watterson","genre":"Humor"}`
-
-        expect(message).toMatch(expectedMessage);
-        restoreConsole();
-
     });
 
+    describe("tests where backend is working normally", () => {
+
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/books", { params: { id: 17 } }).reply(200, {
+                id: 17,
+                name: "The Hobbit",
+                author: "J. R. R. Tolkien",
+                genre: "High Fantasy"  
+            });
+            axiosMock.onPut('/api/books').reply(200, {
+                id: 17,
+                name: "The Hobbit 2",
+                author: "J. R. R. Tolkien 2",
+                genre: "High Fantasy 2"  
+            });
+        });
+
+        const queryClient = new QueryClient();
+        test("renders without crashing", () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <BookEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+        });
+
+        test("Is populated with the data provided", async () => {
+
+            const { getByTestId, findByTestId } = render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <BookEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await findByTestId("BookForm-name");
+
+            const idField = getByTestId("BookForm-id");
+            const authorField = getByTestId("BookForm-author");
+            const nameField = getByTestId("BookForm-name");
+            const genreField = getByTestId("BookForm-genre");
+            const submitButton = getByTestId("BookForm-submit");
+
+            expect(idField).toHaveValue("17");
+            expect(authorField).toHaveValue("J. R. R. Tolkien");
+            expect(nameField).toHaveValue("The Hobbit");
+            expect(genreField).toHaveValue("High Fantasy");
+        });
+
+        test("Changes when you click Update", async () => {
+
+
+
+            const { getByTestId, findByTestId } = render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <BookEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await findByTestId("BookForm-author");
+
+            const idField = getByTestId("BookForm-id");
+            const authorField = getByTestId("BookForm-author");
+            const nameField = getByTestId("BookForm-name");
+            const genreField = getByTestId("BookForm-genre");
+            const submitButton = getByTestId("BookForm-submit");
+
+            expect(idField).toHaveValue("17");
+            expect(authorField).toHaveValue("J. R. R. Tolkien");
+            expect(nameField).toHaveValue("The Hobbit");
+            expect(genreField).toHaveValue("High Fantasy");
+
+            expect(submitButton).toBeInTheDocument();
+
+            fireEvent.change(authorField, { target: { value: "J. R. R. Tolkien 2" } })
+            fireEvent.change(nameField, { target: { value: "The Hobbit 2" } })
+            fireEvent.change(genreField, { target: { value: "High Fantasy 2" } })
+
+            fireEvent.click(submitButton);
+
+            await waitFor(() => expect(mockToast).toBeCalled);
+            expect(mockToast).toBeCalledWith("Book Updated - id: 17 name: The Hobbit 2");
+            expect(mockNavigate).toBeCalledWith({ "to": "/books/" });
+
+            expect(axiosMock.history.put.length).toBe(1); // times called
+            expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+            expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
+                author: "J. R. R. Tolkien 2",
+                name: "The Hobbit 2",
+                genre: "High Fantasy 2"
+            })); // posted object
+
+        });
+
+       
+    });
 });
+
 
 

--- a/frontend/src/tests/pages/Books/BookIndexPage.test.js
+++ b/frontend/src/tests/pages/Books/BookIndexPage.test.js
@@ -1,4 +1,4 @@
-import { render, fireEvent, waitFor, getAllByTestId, findAllByTestId } from "@testing-library/react";
+import { render, fireEvent, waitFor, screen, mockNavigate, getAllByTestId, findAllByTestId } from "@testing-library/react";
 import BookIndexPage from "main/pages/Books/BookIndexPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -6,11 +6,15 @@ import mockConsole from "jest-mock-console";
 import { bookFixtures } from "fixtures/bookFixtures";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
-import AxiosMockAdapter  from "axios-mock-adapter";
+import AxiosMockAdapter from "axios-mock-adapter";
 import axios from "axios";
 
+const mockedNavigate = jest.fn();
 
-
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
 
 const mockToast = jest.fn();
 jest.mock('react-toastify', () => {
@@ -24,7 +28,7 @@ jest.mock('react-toastify', () => {
 
 describe("BookIndexPage tests", () => {
 
-    const axiosMock =new AxiosMockAdapter(axios);
+    const axiosMock = new AxiosMockAdapter(axios);
 
     const testId = "BookTable";
 
@@ -154,18 +158,33 @@ describe("BookIndexPage tests", () => {
 
         await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
 
-       expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2"); 
+        expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
 
 
         const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
         expect(deleteButton).toBeInTheDocument();
-       
+
         fireEvent.click(deleteButton);
 
         await waitFor(() => { expect(mockToast).toBeCalledWith("Book with id 1 was deleted") });
 
     });
 
+    test("Create button navigates to create Book page", async () => {
+        const queryClient = new QueryClient();
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <BookIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        const createButton = screen.getByText("Create Book");
+        expect(createButton).toBeInTheDocument();
+        expect(createButton).toHaveAttribute("style", "float: right;");
+        expect(createButton).toHaveAttribute("href", "/books/create");
+
+    });
 });
 
 

--- a/frontend/src/tests/pages/Books/BookIndexPage.test.js
+++ b/frontend/src/tests/pages/Books/BookIndexPage.test.js
@@ -1,54 +1,52 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, fireEvent, waitFor, getAllByTestId, findAllByTestId } from "@testing-library/react";
 import BookIndexPage from "main/pages/Books/BookIndexPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import mockConsole from "jest-mock-console";
-
-import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
+import { bookFixtures } from "fixtures/bookFixtures";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import AxiosMockAdapter  from "axios-mock-adapter";
 import axios from "axios";
-import AxiosMockAdapter from "axios-mock-adapter";
 
-const mockNavigate = jest.fn();
-jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    useNavigate: () => mockNavigate
-}));
 
-const mockDelete = jest.fn();
-jest.mock('main/utils/bookUtils', () => {
+
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
     return {
         __esModule: true,
-        bookUtils: {
-            del: (id) => {
-                return mockDelete(id);
-            },
-            get: () => {
-                return {
-                    nextId: 5,
-                    books: [
-                        {
-                            "id": 3,
-                            "name": "The Great Gatsby",
-                            "author": "F. Scott Fitzgerald",
-                            "genre": "Tragedy"  
-                        },
-                    ]
-                }
-            }
-        }
-    }
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
 });
-
 
 describe("BookIndexPage tests", () => {
 
     const axiosMock =new AxiosMockAdapter(axios);
-    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
 
-    const queryClient = new QueryClient();
-    test("renders without crashing", () => {
+    const testId = "BookTable";
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    test("renders without crashing for regular user", () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/books/all").reply(200, []);
+
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -56,9 +54,15 @@ describe("BookIndexPage tests", () => {
                 </MemoryRouter>
             </QueryClientProvider>
         );
+
+
     });
 
-    test("renders correct fields", () => {
+    test("renders without crashing for admin user", () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/books/all").reply(200, []);
+
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -67,29 +71,55 @@ describe("BookIndexPage tests", () => {
             </QueryClientProvider>
         );
 
-        const createBookButton = screen.getByText("Create Book");
-        expect(createBookButton).toBeInTheDocument();
-        expect(createBookButton).toHaveAttribute("style", "float: right;");
 
-        const name = screen.getByText("The Great Gatsby");
-        expect(name).toBeInTheDocument();
-
-        const author = screen.getByText("F. Scott Fitzgerald");
-        expect(author).toBeInTheDocument();
-        
-        const genre = screen.getByText("Tragedy");
-        expect(genre).toBeInTheDocument();
-
-        expect(screen.getByTestId("BookTable-cell-row-0-col-Delete-button")).toBeInTheDocument();
-        expect(screen.getByTestId("BookTable-cell-row-0-col-Details-button")).toBeInTheDocument();
-        expect(screen.getByTestId("BookTable-cell-row-0-col-Edit-button")).toBeInTheDocument();
     });
 
-    test("delete button calls delete and reloads page", async () => {
+    test("renders three books without crashing for regular user", async () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/books/all").reply(200, bookFixtures.threeBooks);
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <BookIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); });
+        expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+
+    });
+
+    test("renders three books without crashing for admin user", async () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/books/all").reply(200, bookFixtures.threeBooks);
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <BookIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); });
+        expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+
+    });
+
+    test("renders empty table when backend unavailable, user only", async () => {
+        setupUserOnly();
+
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/books/all").timeout();
 
         const restoreConsole = mockConsole();
 
-        render(
+        const { queryByTestId } = render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <BookIndexPage />
@@ -97,32 +127,42 @@ describe("BookIndexPage tests", () => {
             </QueryClientProvider>
         );
 
-        const name = screen.getByText("The Great Gatsby");
-        expect(name).toBeInTheDocument();
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
 
-        const author = screen.getByText("F. Scott Fitzgerald");
-        expect(author).toBeInTheDocument();
-
-        const genre = screen.getByText("Tragedy");
-        expect(genre).toBeInTheDocument();
-
-        const deleteButton = screen.getByTestId("BookTable-cell-row-0-col-Delete-button");
-        expect(deleteButton).toBeInTheDocument();
-
-        deleteButton.click();
-
-        expect(mockDelete).toHaveBeenCalledTimes(1);
-        expect(mockDelete).toHaveBeenCalledWith(3);
-
-        await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/books"));
-
-
-        // assert - check that the console.log was called with the expected message
-        expect(console.log).toHaveBeenCalled();
-        const message = console.log.mock.calls[0][0];
-        const expectedMessage = `BookIndexPage deleteCallback: {"id":3,"name":"The Great Gatsby","author":"F. Scott Fitzgerald","genre":"Tragedy"}`;
-        expect(message).toMatch(expectedMessage);
+        const errorMessage = console.error.mock.calls[0][0];
+        expect(errorMessage).toMatch("Error communicating with backend via GET on /api/books/all");
         restoreConsole();
+
+        expect(queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+    });
+
+    test("what happens when you click delete, admin", async () => {
+        setupAdminUser();
+
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/books/all").reply(200, bookFixtures.threeBooks);
+        axiosMock.onDelete("/api/books").reply(200, "Book with id 1 was deleted");
+
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <BookIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
+
+       expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); 
+
+
+        const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
+       
+        fireEvent.click(deleteButton);
+
+        await waitFor(() => { expect(mockToast).toBeCalledWith("Book with id 1 was deleted") });
 
     });
 

--- a/frontend/src/tests/pages/Books/BookIndexPage.test.js
+++ b/frontend/src/tests/pages/Books/BookIndexPage.test.js
@@ -86,9 +86,9 @@ describe("BookIndexPage tests", () => {
                 </MemoryRouter>
             </QueryClientProvider>
         );
-        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); });
-        expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
-        expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2"); });
+        expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("3");
+        expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("4");
 
     });
 
@@ -105,9 +105,9 @@ describe("BookIndexPage tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); });
-        expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
-        expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2"); });
+        expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("3");
+        expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("4");
 
     });
 
@@ -154,7 +154,7 @@ describe("BookIndexPage tests", () => {
 
         await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
 
-       expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); 
+       expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2"); 
 
 
         const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);

--- a/frontend/src/tests/utils/bookUtils.test.js
+++ b/frontend/src/tests/utils/bookUtils.test.js
@@ -1,290 +1,58 @@
-import { bookFixtures } from "fixtures/bookFixtures";
-import { bookUtils } from "main/utils/bookUtils";
+import { onDeleteSuccess, cellToAxiosParamsDelete, editCallback } from "main/utils/bookUtils";
+import mockConsole from "jest-mock-console";
 
-describe("bookUtils tests", () => {
-    // return a function that can be used as a mock implementation of getItem
-    // the value passed in will be convertd to JSON and returned as the value
-    // for the key "books".  Any other key results in an error
-    const createGetItemMock = (returnValue) => (key) => {
-        if (key === "books") {
-            return JSON.stringify(returnValue);
-        } else {
-            throw new Error("Unexpected key: " + key);
-        }
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
     };
+});
 
-    describe("get", () => {
+describe("bookUtils", () => {
 
-        test("When books is undefined in local storage, should set to empty list", () => {
+    describe("onDeleteSuccess", () => {
 
+        test("It puts the message on console.log and in a toast", () => {
             // arrange
-            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
-            getItemSpy.mockImplementation(createGetItemMock(undefined));
-
-            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
-            setItemSpy.mockImplementation((_key, _value) => null);
+            const restoreConsole = mockConsole();
 
             // act
-            const result = bookUtils.get();
+            onDeleteSuccess("abc");
 
             // assert
-            const expected = { nextId: 1, books: [] } ;
-            expect(result).toEqual(expected);
+            expect(mockToast).toHaveBeenCalledWith("abc");
+            expect(console.log).toHaveBeenCalled();
+            const message = console.log.mock.calls[0][0];
+            expect(message).toMatch("abc");
 
-            const expectedJSON = JSON.stringify(expected);
-            expect(setItemSpy).toHaveBeenCalledWith("books", expectedJSON);
-        });
-
-        test("When books is null in local storage, should set to empty list", () => {
-
-            // arrange
-            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
-            getItemSpy.mockImplementation(createGetItemMock(null));
-
-            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
-            setItemSpy.mockImplementation((_key, _value) => null);
-
-            // act
-            const result = bookUtils.get();
-
-            // assert
-            const expected = { nextId: 1, books: [] } ;
-            expect(result).toEqual(expected);
-
-            const expectedJSON = JSON.stringify(expected);
-            expect(setItemSpy).toHaveBeenCalledWith("books", expectedJSON);
-        });
-
-        test("When books is [] in local storage, should return []", () => {
-
-            // arrange
-            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
-            getItemSpy.mockImplementation(createGetItemMock({ nextId: 1, books: [] }));
-
-            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
-            setItemSpy.mockImplementation((_key, _value) => null);
-
-            // act
-            const result = bookUtils.get();
-
-            // assert
-            const expected = { nextId: 1, books: [] };
-            expect(result).toEqual(expected);
-
-            expect(setItemSpy).not.toHaveBeenCalled();
-        });
-
-        test("When books is JSON of three books, should return that JSON", () => {
-
-            // arrange
-            const threeBooks = bookFixtures.threeBooks;
-            const mockBookCollection = { nextId: 10, books: threeBooks };
-
-            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
-            getItemSpy.mockImplementation(createGetItemMock(mockBookCollection));
-
-            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
-            setItemSpy.mockImplementation((_key, _value) => null);
-
-            // act
-            const result = bookUtils.get();
-
-            // assert
-            expect(result).toEqual(mockBookCollection);
-            expect(setItemSpy).not.toHaveBeenCalled();
-        });
-    });
-
-
-    describe("getById", () => {
-        test("Check that getting a book by id works", () => {
-
-            // arrange
-            const threeBooks = bookFixtures.threeBooks;
-            const idToGet = threeBooks[1].id;
-
-            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
-            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, books: threeBooks }));
-
-            // act
-            const result = bookUtils.getById(idToGet);
-
-            // assert
-
-            const expected = { book: threeBooks[1] };
-            expect(result).toEqual(expected);
-        });
-
-        test("Check that getting a non-existing book returns an error", () => {
-
-            // arrange
-            const threeBooks = bookFixtures.threeBooks;
-
-            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
-            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, books: threeBooks }));
-
-            // act
-            const result = bookUtils.getById(99);
-
-            // assert
-            const expectedError = `book with id 99 not found`
-            expect(result).toEqual({ error: expectedError });
-        });
-
-        test("Check that an error is returned when id not passed", () => {
-
-            // arrange
-            const threeBooks = bookFixtures.threeBooks;
-
-            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
-            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, books: threeBooks }));
-
-            // act
-            const result = bookUtils.getById();
-
-            // assert
-            const expectedError = `id is a required parameter`
-            expect(result).toEqual({ error: expectedError });
+            restoreConsole();
         });
 
     });
-    describe("add", () => {
-        test("Starting from [], check that adding one book works", () => {
+    describe("cellToAxiosParamsDelete", () => {
 
+        test("It returns the correct params", () => {
             // arrange
-            const book = bookFixtures.oneBook[0];
-            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
-            getItemSpy.mockImplementation(createGetItemMock({ nextId: 1, books: [] }));
-
-            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
-            setItemSpy.mockImplementation((_key, _value) => null);
+            const cell = { row: { values: { id: 17 } } };
 
             // act
-            const result = bookUtils.add(book);
+            const result = cellToAxiosParamsDelete(cell);
 
             // assert
-            expect(result).toEqual(book);
-            expect(setItemSpy).toHaveBeenCalledWith("books",
-                JSON.stringify({ nextId: 2, books: bookFixtures.oneBook }));
+            expect(result).toEqual({
+                url: "/api/books",
+                method: "DELETE",
+                params: { id: 17 }
+            });
         });
-    });
 
-    describe("update", () => {
-        test("Check that updating an existing book works", () => {
-
-            // arrange
-            const threeBooks = bookFixtures.threeBooks;
-            const updatedBook = {
-                ...threeBooks[0],
-                name: "Updated Name"
-            };
-            const threeBooksUpdated = [
-                updatedBook,
-                threeBooks[1],
-                threeBooks[2]
-            ];
-
-            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
-            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, books: threeBooks }));
-
-            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
-            setItemSpy.mockImplementation((_key, _value) => null);
-
-            // act
-            const result = bookUtils.update(updatedBook);
-
-            // assert
-            const expected = { bookCollection: { nextId: 5, books: threeBooksUpdated } };
-            expect(result).toEqual(expected);
-            expect(setItemSpy).toHaveBeenCalledWith("books", JSON.stringify(expected.bookCollection));
-        });
-        test("Check that updating an non-existing book returns an error", () => {
-
-            // arrange
-            const threeBooks = bookFixtures.threeBooks;
-
-            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
-            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, books: threeBooks }));
-
-            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
-            setItemSpy.mockImplementation((_key, _value) => null);
-
-            const updatedBook = {
-                id: 99,
-                name: "Fake Name",
-                description: "Fake Description"
-            }
-
-            // act
-            const result = bookUtils.update(updatedBook);
-
-            // assert
-            const expectedError = `book with id 99 not found`
-            expect(result).toEqual({ error: expectedError });
-            expect(setItemSpy).not.toHaveBeenCalled();
-        });
-    });
-
-    describe("del", () => {
-        test("Check that deleting a book by id works", () => {
-
-            // arrange
-            const threeBooks = bookFixtures.threeBooks;
-            const idToDelete = threeBooks[1].id;
-            const threeBooksUpdated = [
-                threeBooks[0],
-                threeBooks[2]
-            ];
-
-            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
-            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, books: threeBooks }));
-
-            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
-            setItemSpy.mockImplementation((_key, _value) => null);
-
-            // act
-            const result = bookUtils.del(idToDelete);
-
-            // assert
-
-            const expected = { bookCollection: { nextId: 5, books: threeBooksUpdated } };
-            expect(result).toEqual(expected);
-            expect(setItemSpy).toHaveBeenCalledWith("books", JSON.stringify(expected.bookCollection));
-        });
-        test("Check that deleting a non-existing book returns an error", () => {
-
-            // arrange
-            const threeBooks = bookFixtures.threeBooks;
-
-            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
-            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, books: threeBooks }));
-
-            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
-            setItemSpy.mockImplementation((_key, _value) => null);
-
-            // act
-            const result = bookUtils.del(99);
-
-            // assert
-            const expectedError = `book with id 99 not found`
-            expect(result).toEqual({ error: expectedError });
-            expect(setItemSpy).not.toHaveBeenCalled();
-        });
-        test("Check that an error is returned when id not passed", () => {
-
-            // arrange
-            const threeBooks = bookFixtures.threeBooks;
-
-            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
-            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, books: threeBooks }));
-
-            // act
-            const result = bookUtils.del();
-
-            // assert
-            const expectedError = `id is a required parameter`
-            expect(result).toEqual({ error: expectedError });
-        });
     });
 });
+
+
+
+
 

--- a/src/main/java/edu/ucsb/cs156/example/controllers/BookController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/BookController.java
@@ -25,6 +25,7 @@ import javax.validation.Valid;
 @Api(description = "Book")
 @RequestMapping("/api/books")
 @RestController
+@Slf4j
 public class BookController extends ApiController {
 
     @Autowired

--- a/src/main/java/edu/ucsb/cs156/example/controllers/BookController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/BookController.java
@@ -23,9 +23,8 @@ import javax.validation.Valid;
 
 
 @Api(description = "Book")
-@RequestMapping("/api/book")
+@RequestMapping("/api/books")
 @RestController
-@Slf4j
 public class BookController extends ApiController {
 
     @Autowired

--- a/src/main/java/edu/ucsb/cs156/example/entities/Book.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/Book.java
@@ -14,7 +14,7 @@ import lombok.Builder;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@Entity(name = "book")
+@Entity(name = "books")
 public class Book {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/test/java/edu/ucsb/cs156/example/controllers/BookControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/BookControllerTests.java
@@ -40,41 +40,41 @@ public class BookControllerTests extends ControllerTestCase {
         @MockBean
         UserRepository userRepository;
 
-        // Authorization tests for /api/book/admin/all
+        // Authorization tests for /api/books/admin/all
 
         @Test
         public void logged_out_users_cannot_get_all() throws Exception {
-                mockMvc.perform(get("/api/book/all"))
+                mockMvc.perform(get("/api/books/all"))
                                 .andExpect(status().is(403)); // logged out users can't get all
         }
 
         @WithMockUser(roles = { "USER" })
         @Test
         public void logged_in_users_can_get_all() throws Exception {
-                mockMvc.perform(get("/api/book/all"))
+                mockMvc.perform(get("/api/books/all"))
                                 .andExpect(status().is(200)); // logged
         }
 
         
         @Test
         public void logged_out_users_cannot_get_by_id() throws Exception {
-                mockMvc.perform(get("/api/book?id=1"))
+                mockMvc.perform(get("/api/books?id=1"))
                                 .andExpect(status().is(403)); // logged out users can't get by id
         }
 
-        // Authorization tests for /api/book/post
+        // Authorization tests for /api/books/post
         // (Perhaps should also have these for put and delete)
 
         @Test
         public void logged_out_users_cannot_post() throws Exception {
-                mockMvc.perform(post("/api/book/post"))
+                mockMvc.perform(post("/api/books/post"))
                                 .andExpect(status().is(403));
         }
 
         @WithMockUser(roles = { "USER" })
         @Test
         public void logged_in_regular_users_cannot_post() throws Exception {
-                mockMvc.perform(post("/api/book/post"))
+                mockMvc.perform(post("/api/books/post"))
                                 .andExpect(status().is(403)); // only admins can post
         }
 
@@ -95,7 +95,7 @@ public class BookControllerTests extends ControllerTestCase {
                 when(bookRepository.findById(1L)).thenReturn(Optional.of(greenEggs));
 
                 // act
-                MvcResult response = mockMvc.perform(get("/api/book?id=1"))
+                MvcResult response = mockMvc.perform(get("/api/books?id=1"))
                                 .andExpect(status().isOk()).andReturn();
 
                 // assert
@@ -115,7 +115,7 @@ public class BookControllerTests extends ControllerTestCase {
                 when(bookRepository.findById(-1L)).thenReturn(Optional.empty());
 
                 // act
-                MvcResult response = mockMvc.perform(get("/api/book?id=-1"))
+                MvcResult response = mockMvc.perform(get("/api/books?id=-1"))
                                 .andExpect(status().isNotFound()).andReturn();
 
                 // assert
@@ -150,7 +150,7 @@ public class BookControllerTests extends ControllerTestCase {
                 when(bookRepository.findAll()).thenReturn(expectedBooks);
 
                 // act
-                MvcResult response = mockMvc.perform(get("/api/book/all"))
+                MvcResult response = mockMvc.perform(get("/api/books/all"))
                                 .andExpect(status().isOk()).andReturn();
 
                 // assert
@@ -176,7 +176,7 @@ public class BookControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                post("/api/book/post?name=GreenEggsAndHam&genre=Poetry&author=DrSeuss")
+                                post("/api/books/post?name=GreenEggsAndHam&genre=Poetry&author=DrSeuss")
                                                 .with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 
@@ -202,7 +202,7 @@ public class BookControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                delete("/api/book?id=1")
+                                delete("/api/books?id=1")
                                                 .with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 
@@ -224,7 +224,7 @@ public class BookControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                delete("/api/book?id=100")
+                                delete("/api/books?id=100")
                                                 .with(csrf()))
                                 .andExpect(status().isNotFound()).andReturn();
 
@@ -258,7 +258,7 @@ public class BookControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                put("/api/book?id=25")
+                                put("/api/books?id=25")
                                                 .contentType(MediaType.APPLICATION_JSON)
                                                 .characterEncoding("utf-8")
                                                 .content(requestBody)
@@ -289,7 +289,7 @@ public class BookControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                put("/api/book?id=25")
+                                put("/api/books?id=25")
                                                 .contentType(MediaType.APPLICATION_JSON)
                                                 .characterEncoding("utf-8")
                                                 .content(requestBody)


### PR DESCRIPTION
In this PR, we change the Book pages and tests to use the API for managing data. Book tests were modified to reflect this change. I also changed the API endpoint from `book` to `books` for consistency with class names and the other endpoints, and reverted `frontend/package.json` because I changed it on accident.

Closes #9 